### PR TITLE
Add handlesCuries method to all handlers so Symfony autoconfigure works.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 2
+continuation_indent_size = 4
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true

--- a/CHANGELOG-0.x.md
+++ b/CHANGELOG-0.x.md
@@ -2,5 +2,14 @@
 This changelog references the relevant changes done in 0.x versions.
 
 
+## v0.2.0
+__BREAKING CHANGES__
+
+* Require `"gdbots/ncr": "~0.2"`.
+* Add `handlesCuries` method to all handlers so Symfony autoconfigure works.
+* Add `PbjxValidator` and `PbjxProjector` marker interfaces to appropriate classes.
+* issue #5: Update `RoleProjector` to use hard delete.
+
+
 ## v0.1.0
 * Initial version.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ iam-php
 [![Code Climate](https://codeclimate.com/github/gdbots/iam-php/badges/gpa.svg)](https://codeclimate.com/github/gdbots/iam-php)
 [![Test Coverage](https://codeclimate.com/github/gdbots/iam-php/badges/coverage.svg)](https://codeclimate.com/github/gdbots/iam-php/coverage)
 
-Php library that provides implementations for __gdbots:iam__ schemas.   Using this library assumes that you've already created and compiled your own pbj classes using the [Pbjc](https://github.com/gdbots/pbjc-php) and are making use of the __"gdbots:iam:mixin:*"__ mixins from [gdbots/schemas](https://github.com/gdbots/schemas).
+Php library that provides implementations for __gdbots:iam__ schemas.   Using this library assumes that you've 
+already created and compiled your own pbj classes using the [Pbjc](https://github.com/gdbots/pbjc-php) and are 
+making use of the __"gdbots:iam:mixin:*"__ mixins from [gdbots/schemas](https://github.com/gdbots/schemas).
 
-> If your project is using Symfony use the [gdbots/iam-bundle-php](https://github.com/gdbots/iam-bundle-php) to simplify the integration.
+> If your project is using Symfony use the [gdbots/iam-bundle-php](https://github.com/gdbots/iam-bundle-php)
+> to simplify the integration.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "require": {
     "php": ">=7.1",
-    "gdbots/ncr": "~0.1"
+    "gdbots/ncr": "~0.2"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.4",
@@ -26,7 +26,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "0.1.x-dev"
+      "dev-master": "0.2.x-dev"
     }
   }
 }

--- a/src/CreateRoleHandler.php
+++ b/src/CreateRoleHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\CommandHandlerTrait;
 use Gdbots\Pbjx\Pbjx;
 use Gdbots\Schemas\Iam\Mixin\CreateRole\CreateRole;
+use Gdbots\Schemas\Iam\Mixin\CreateRole\CreateRoleV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\Role\Role;
 use Gdbots\Schemas\Iam\Mixin\RoleCreated\RoleCreatedV1Mixin;
 use Gdbots\Schemas\Ncr\Enum\NodeStatus;
@@ -42,5 +43,15 @@ final class CreateRoleHandler implements CommandHandler
 
         $streamId = StreamId::fromString(sprintf('role.history:%s', $node->get('_id')));
         $pbjx->getEventStore()->putEvents($streamId, [$event]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            CreateRoleV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/CreateUserHandler.php
+++ b/src/CreateUserHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\CommandHandlerTrait;
 use Gdbots\Pbjx\Pbjx;
 use Gdbots\Schemas\Iam\Mixin\CreateUser\CreateUser;
+use Gdbots\Schemas\Iam\Mixin\CreateUser\CreateUserV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\User\User;
 use Gdbots\Schemas\Iam\Mixin\UserCreated\UserCreatedV1Mixin;
 use Gdbots\Schemas\Ncr\Enum\NodeStatus;
@@ -54,5 +55,15 @@ final class CreateUserHandler implements CommandHandler
 
         $streamId = StreamId::fromString(sprintf('user.history:%s', $node->get('_id')));
         $pbjx->getEventStore()->putEvents($streamId, [$event]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            CreateUserV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/DeleteRoleHandler.php
+++ b/src/DeleteRoleHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\CommandHandlerTrait;
 use Gdbots\Pbjx\Pbjx;
 use Gdbots\Schemas\Iam\Mixin\DeleteRole\DeleteRole;
+use Gdbots\Schemas\Iam\Mixin\DeleteRole\DeleteRoleV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\RoleDeleted\RoleDeletedV1Mixin;
 use Gdbots\Schemas\Pbjx\StreamId;
 
@@ -26,5 +27,15 @@ final class DeleteRoleHandler implements CommandHandler
 
         $streamId = StreamId::fromString(sprintf('role.history:%s', $event->get('node_ref')->getId()));
         $pbjx->getEventStore()->putEvents($streamId, [$event]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            DeleteRoleV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/DeleteUserHandler.php
+++ b/src/DeleteUserHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\CommandHandlerTrait;
 use Gdbots\Pbjx\Pbjx;
 use Gdbots\Schemas\Iam\Mixin\DeleteUser\DeleteUser;
+use Gdbots\Schemas\Iam\Mixin\DeleteUser\DeleteUserV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\UserDeleted\UserDeletedV1Mixin;
 use Gdbots\Schemas\Pbjx\StreamId;
 
@@ -26,5 +27,15 @@ final class DeleteUserHandler implements CommandHandler
 
         $streamId = StreamId::fromString(sprintf('user.history:%s', $event->get('node_ref')->getId()));
         $pbjx->getEventStore()->putEvents($streamId, [$event]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            DeleteUserV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/GetRoleBatchRequestHandler.php
+++ b/src/GetRoleBatchRequestHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Ncr\Ncr;
 use Gdbots\Pbjx\RequestHandler;
 use Gdbots\Pbjx\RequestHandlerTrait;
 use Gdbots\Schemas\Iam\Mixin\GetRoleBatchRequest\GetRoleBatchRequest;
+use Gdbots\Schemas\Iam\Mixin\GetRoleBatchRequest\GetRoleBatchRequestV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\GetRoleBatchResponse\GetRoleBatchResponse;
 use Gdbots\Schemas\Iam\Mixin\GetRoleBatchResponse\GetRoleBatchResponseV1Mixin;
 use Gdbots\Schemas\Ncr\NodeRef;
@@ -54,5 +55,15 @@ final class GetRoleBatchRequestHandler implements RequestHandler
         $response->addToSet('missing_node_refs', $missing);
 
         return $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            GetRoleBatchRequestV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/GetRoleHistoryRequestHandler.php
+++ b/src/GetRoleHistoryRequestHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Pbjx\Pbjx;
 use Gdbots\Pbjx\RequestHandler;
 use Gdbots\Pbjx\RequestHandlerTrait;
 use Gdbots\Schemas\Iam\Mixin\GetRoleHistoryRequest\GetRoleHistoryRequest;
+use Gdbots\Schemas\Iam\Mixin\GetRoleHistoryRequest\GetRoleHistoryRequestV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\GetRoleHistoryResponse\GetRoleHistoryResponse;
 use Gdbots\Schemas\Iam\Mixin\GetRoleHistoryResponse\GetRoleHistoryResponseV1Mixin;
 
@@ -37,5 +38,15 @@ final class GetRoleHistoryRequestHandler implements RequestHandler
             ->set('has_more', $slice->hasMore())
             ->set('last_occurred_at', $slice->getLastOccurredAt())
             ->addToList('events', $slice->toArray()['events']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            GetRoleHistoryRequestV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/GetRoleRequestHandler.php
+++ b/src/GetRoleRequestHandler.php
@@ -8,6 +8,7 @@ use Gdbots\Ncr\Ncr;
 use Gdbots\Pbjx\RequestHandler;
 use Gdbots\Pbjx\RequestHandlerTrait;
 use Gdbots\Schemas\Iam\Mixin\GetRoleRequest\GetRoleRequest;
+use Gdbots\Schemas\Iam\Mixin\GetRoleRequest\GetRoleRequestV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\GetRoleResponse\GetRoleResponse;
 use Gdbots\Schemas\Iam\Mixin\GetRoleResponse\GetRoleResponseV1Mixin;
 
@@ -43,5 +44,15 @@ final class GetRoleRequestHandler implements RequestHandler
         /** @var GetRoleResponse $response */
         $response = $schema->createMessage();
         return $response->set('node', $node);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            GetRoleRequestV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/GetUserBatchRequestHandler.php
+++ b/src/GetUserBatchRequestHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Ncr\Ncr;
 use Gdbots\Pbjx\RequestHandler;
 use Gdbots\Pbjx\RequestHandlerTrait;
 use Gdbots\Schemas\Iam\Mixin\GetUserBatchRequest\GetUserBatchRequest;
+use Gdbots\Schemas\Iam\Mixin\GetUserBatchRequest\GetUserBatchRequestV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\GetUserBatchResponse\GetUserBatchResponse;
 use Gdbots\Schemas\Iam\Mixin\GetUserBatchResponse\GetUserBatchResponseV1Mixin;
 use Gdbots\Schemas\Ncr\NodeRef;
@@ -54,5 +55,15 @@ final class GetUserBatchRequestHandler implements RequestHandler
         $response->addToSet('missing_node_refs', $missing);
 
         return $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            GetUserBatchRequestV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/GetUserHistoryRequestHandler.php
+++ b/src/GetUserHistoryRequestHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Pbjx\Pbjx;
 use Gdbots\Pbjx\RequestHandler;
 use Gdbots\Pbjx\RequestHandlerTrait;
 use Gdbots\Schemas\Iam\Mixin\GetUserHistoryRequest\GetUserHistoryRequest;
+use Gdbots\Schemas\Iam\Mixin\GetUserHistoryRequest\GetUserHistoryRequestV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\GetUserHistoryResponse\GetUserHistoryResponse;
 use Gdbots\Schemas\Iam\Mixin\GetUserHistoryResponse\GetUserHistoryResponseV1Mixin;
 
@@ -37,5 +38,15 @@ final class GetUserHistoryRequestHandler implements RequestHandler
             ->set('has_more', $slice->hasMore())
             ->set('last_occurred_at', $slice->getLastOccurredAt())
             ->addToList('events', $slice->toArray()['events']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            GetUserHistoryRequestV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/GetUserRequestHandler.php
+++ b/src/GetUserRequestHandler.php
@@ -10,6 +10,7 @@ use Gdbots\Pbj\SchemaQName;
 use Gdbots\Pbjx\RequestHandler;
 use Gdbots\Pbjx\RequestHandlerTrait;
 use Gdbots\Schemas\Iam\Mixin\GetUserRequest\GetUserRequest;
+use Gdbots\Schemas\Iam\Mixin\GetUserRequest\GetUserRequestV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\GetUserResponse\GetUserResponse;
 use Gdbots\Schemas\Iam\Mixin\GetUserResponse\GetUserResponseV1Mixin;
 
@@ -56,5 +57,15 @@ final class GetUserRequestHandler implements RequestHandler
         /** @var GetUserResponse $response */
         $response = $schema->createMessage();
         return $response->set('node', $node);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            GetUserRequestV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/GrantRolesToUserHandler.php
+++ b/src/GrantRolesToUserHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\CommandHandlerTrait;
 use Gdbots\Pbjx\Pbjx;
 use Gdbots\Schemas\Iam\Mixin\GrantRolesToUser\GrantRolesToUser;
+use Gdbots\Schemas\Iam\Mixin\GrantRolesToUser\GrantRolesToUserV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\UserRolesGranted\UserRolesGrantedV1Mixin;
 use Gdbots\Schemas\Pbjx\StreamId;
 
@@ -28,5 +29,15 @@ final class GrantRolesToUserHandler implements CommandHandler
 
         $streamId = StreamId::fromString(sprintf('user.history:%s', $event->get('node_ref')->getId()));
         $pbjx->getEventStore()->putEvents($streamId, [$event]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            GrantRolesToUserV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/ListAllRolesRequestHandler.php
+++ b/src/ListAllRolesRequestHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Ncr\Ncr;
 use Gdbots\Pbj\SchemaQName;
 use Gdbots\Pbjx\RequestHandler;
 use Gdbots\Pbjx\RequestHandlerTrait;
+use Gdbots\Schemas\Iam\Mixin\ListAllRolesRequest\ListAllRolesRequestV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\ListAllRolesResponse\ListAllRolesResponse;
 use Gdbots\Schemas\Iam\Mixin\ListAllRolesResponse\ListAllRolesResponseV1Mixin;
 use Gdbots\Schemas\Ncr\NodeRef;
@@ -43,5 +44,15 @@ final class ListAllRolesRequestHandler implements RequestHandler
         });
 
         return $response->addToSet('roles', $roles);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            ListAllRolesRequestV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/RevokeRolesFromUserHandler.php
+++ b/src/RevokeRolesFromUserHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\CommandHandlerTrait;
 use Gdbots\Pbjx\Pbjx;
 use Gdbots\Schemas\Iam\Mixin\RevokeRolesFromUser\RevokeRolesFromUser;
+use Gdbots\Schemas\Iam\Mixin\RevokeRolesFromUser\RevokeRolesFromUserV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\UserRolesRevoked\UserRolesRevokedV1Mixin;
 use Gdbots\Schemas\Pbjx\StreamId;
 
@@ -28,5 +29,15 @@ final class RevokeRolesFromUserHandler implements CommandHandler
 
         $streamId = StreamId::fromString(sprintf('user.history:%s', $event->get('node_ref')->getId()));
         $pbjx->getEventStore()->putEvents($streamId, [$event]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            RevokeRolesFromUserV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/RoleProjector.php
+++ b/src/RoleProjector.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 namespace Gdbots\Iam;
 
 use Gdbots\Ncr\Ncr;
+use Gdbots\Pbjx\DependencyInjection\PbjxProjector;
 use Gdbots\Pbjx\EventSubscriberTrait;
 use Gdbots\Schemas\Iam\Mixin\RoleCreated\RoleCreated;
 use Gdbots\Schemas\Iam\Mixin\RoleDeleted\RoleDeleted;
 use Gdbots\Schemas\Iam\Mixin\RoleUpdated\RoleUpdated;
-use Gdbots\Schemas\Ncr\Enum\NodeStatus;
 use Gdbots\Schemas\Ncr\Mixin\Node\Node;
 use Gdbots\Schemas\Pbjx\Mixin\Event\Event;
 
-class RoleProjector
+class RoleProjector implements PbjxProjector
 {
     use EventSubscriberTrait;
 
@@ -51,10 +51,7 @@ class RoleProjector
      */
     public function onRoleDeleted(RoleDeleted $event): void
     {
-        $node = $this->ncr->getNode($event->get('node_ref'), true);
-        // using soft delete for roles
-        $node->set('status', NodeStatus::DELETED());
-        $this->putNode($node, $event);
+        $this->ncr->deleteNode($event->get('node_ref'));
     }
 
     /**

--- a/src/SearchUsersRequestHandler.php
+++ b/src/SearchUsersRequestHandler.php
@@ -13,6 +13,7 @@ use Gdbots\QueryParser\Node\Word;
 use Gdbots\QueryParser\ParsedQuery;
 use Gdbots\Schemas\Common\Enum\Trinary;
 use Gdbots\Schemas\Iam\Mixin\SearchUsersRequest\SearchUsersRequest;
+use Gdbots\Schemas\Iam\Mixin\SearchUsersRequest\SearchUsersRequestV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\SearchUsersResponse\SearchUsersResponse;
 use Gdbots\Schemas\Iam\Mixin\SearchUsersResponse\SearchUsersResponseV1Mixin;
 use Gdbots\Schemas\Ncr\Enum\NodeStatus;
@@ -73,5 +74,15 @@ final class SearchUsersRequestHandler implements RequestHandler
         );
 
         return $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            SearchUsersRequestV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/UpdateUserHandler.php
+++ b/src/UpdateUserHandler.php
@@ -7,6 +7,7 @@ use Gdbots\Pbjx\CommandHandler;
 use Gdbots\Pbjx\CommandHandlerTrait;
 use Gdbots\Pbjx\Pbjx;
 use Gdbots\Schemas\Iam\Mixin\UpdateUser\UpdateUser;
+use Gdbots\Schemas\Iam\Mixin\UpdateUser\UpdateUserV1Mixin;
 use Gdbots\Schemas\Iam\Mixin\User\User;
 use Gdbots\Schemas\Iam\Mixin\UserUpdated\UserUpdatedV1Mixin;
 use Gdbots\Schemas\Ncr\Enum\NodeStatus;
@@ -78,5 +79,15 @@ final class UpdateUserHandler implements CommandHandler
 
         $streamId = StreamId::fromString(sprintf('user.history:%s', $newNode->get('_id')));
         $pbjx->getEventStore()->putEvents($streamId, [$event]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function handlesCuries(): array
+    {
+        return [
+            UpdateUserV1Mixin::findOne()->getCurie(),
+        ];
     }
 }

--- a/src/UserProjector.php
+++ b/src/UserProjector.php
@@ -5,6 +5,7 @@ namespace Gdbots\Iam;
 
 use Gdbots\Ncr\Ncr;
 use Gdbots\Ncr\NcrSearch;
+use Gdbots\Pbjx\DependencyInjection\PbjxProjector;
 use Gdbots\Pbjx\EventSubscriberTrait;
 use Gdbots\Schemas\Iam\Mixin\UserCreated\UserCreated;
 use Gdbots\Schemas\Iam\Mixin\UserDeleted\UserDeleted;
@@ -15,7 +16,7 @@ use Gdbots\Schemas\Ncr\Enum\NodeStatus;
 use Gdbots\Schemas\Ncr\Mixin\Node\Node;
 use Gdbots\Schemas\Pbjx\Mixin\Event\Event;
 
-class UserProjector
+class UserProjector implements PbjxProjector
 {
     use EventSubscriberTrait;
 

--- a/src/Validator/UniqueRoleValidator.php
+++ b/src/Validator/UniqueRoleValidator.php
@@ -5,6 +5,7 @@ namespace Gdbots\Iam\Validator;
 
 use Gdbots\Iam\Exception\RoleAlreadyExists;
 use Gdbots\Pbj\Assertion;
+use Gdbots\Pbjx\DependencyInjection\PbjxValidator;
 use Gdbots\Pbjx\Event\PbjxEvent;
 use Gdbots\Pbjx\EventSubscriber;
 use Gdbots\Schemas\Iam\Mixin\CreateRole\CreateRole;
@@ -12,7 +13,7 @@ use Gdbots\Schemas\Iam\Mixin\UpdateRole\UpdateRole;
 use Gdbots\Schemas\Iam\RoleId;
 use Gdbots\Schemas\Pbjx\StreamId;
 
-final class UniqueRoleValidator implements EventSubscriber
+final class UniqueRoleValidator implements EventSubscriber, PbjxValidator
 {
     /**
      * @param PbjxEvent $pbjxEvent

--- a/src/Validator/UniqueUserValidator.php
+++ b/src/Validator/UniqueUserValidator.php
@@ -6,6 +6,7 @@ namespace Gdbots\Iam\Validator;
 use Gdbots\Iam\Exception\UserAlreadyExists;
 use Gdbots\Pbj\Assertion;
 use Gdbots\Pbj\WellKnown\Identifier;
+use Gdbots\Pbjx\DependencyInjection\PbjxValidator;
 use Gdbots\Pbjx\Event\PbjxEvent;
 use Gdbots\Pbjx\EventSubscriber;
 use Gdbots\Pbjx\Exception\RequestHandlingFailed;
@@ -17,7 +18,7 @@ use Gdbots\Schemas\Pbjx\Enum\Code;
 use Gdbots\Schemas\Pbjx\Mixin\Request\Request;
 use Gdbots\Schemas\Pbjx\StreamId;
 
-final class UniqueUserValidator implements EventSubscriber
+final class UniqueUserValidator implements EventSubscriber, PbjxValidator
 {
     /**
      * @param PbjxEvent $pbjxEvent

--- a/tests/CreateRoleHandlerTest.php
+++ b/tests/CreateRoleHandlerTest.php
@@ -11,7 +11,7 @@ use Gdbots\Schemas\Ncr\Enum\NodeStatus;
 use Gdbots\Schemas\Pbjx\Mixin\Event\Event;
 use Gdbots\Schemas\Pbjx\StreamId;
 
-class CreateRoleHandlerTest extends AbstractPbjxTest
+final class CreateRoleHandlerTest extends AbstractPbjxTest
 {
     public function testHandleCommand()
     {

--- a/tests/CreateUserHandlerTest.php
+++ b/tests/CreateUserHandlerTest.php
@@ -12,7 +12,7 @@ use Gdbots\Schemas\Ncr\NodeRef;
 use Gdbots\Schemas\Pbjx\Mixin\Event\Event;
 use Gdbots\Schemas\Pbjx\StreamId;
 
-class CreateUserHandlerTest extends AbstractPbjxTest
+final class CreateUserHandlerTest extends AbstractPbjxTest
 {
     public function testHandleCommand()
     {

--- a/tests/DeleteRoleHandlerTest.php
+++ b/tests/DeleteRoleHandlerTest.php
@@ -10,7 +10,7 @@ use Gdbots\Schemas\Ncr\NodeRef;
 use Gdbots\Schemas\Pbjx\Mixin\Event\Event;
 use Gdbots\Schemas\Pbjx\StreamId;
 
-class DeleteRoleHandlerTest extends AbstractPbjxTest
+final class DeleteRoleHandlerTest extends AbstractPbjxTest
 {
     public function testHandleCommand()
     {

--- a/tests/DeleteUserHandlerTest.php
+++ b/tests/DeleteUserHandlerTest.php
@@ -10,7 +10,7 @@ use Gdbots\Schemas\Ncr\NodeRef;
 use Gdbots\Schemas\Pbjx\Mixin\Event\Event;
 use Gdbots\Schemas\Pbjx\StreamId;
 
-class DeleteUserHandlerTest extends AbstractPbjxTest
+final class DeleteUserHandlerTest extends AbstractPbjxTest
 {
     public function testHandleCommand()
     {

--- a/tests/GetRoleBatchRequestHandlerTest.php
+++ b/tests/GetRoleBatchRequestHandlerTest.php
@@ -10,7 +10,7 @@ use Gdbots\Schemas\Ncr\Mixin\Node\Node;
 use Gdbots\Schemas\Ncr\NodeRef;
 use Gdbots\Tests\Iam\AbstractPbjxTest;
 
-class GetRoleBatchRequestHandlerTest extends AbstractPbjxTest
+final class GetRoleBatchRequestHandlerTest extends AbstractPbjxTest
 {
     public function testHandleRequest()
     {

--- a/tests/GetRoleHistoryResquestHandlerTest.php
+++ b/tests/GetRoleHistoryResquestHandlerTest.php
@@ -11,7 +11,7 @@ use Gdbots\Pbj\WellKnown\Microtime;
 use Gdbots\Schemas\Pbjx\StreamId;
 use Gdbots\Tests\Iam\AbstractPbjxTest;
 
-class GetRoleHistoryResquestHandlerTest extends AbstractPbjxTest
+final class GetRoleHistoryResquestHandlerTest extends AbstractPbjxTest
 {
     /**
      * testHandleRequest. Test with default args

--- a/tests/GetRoleRequestHandlerTest.php
+++ b/tests/GetRoleRequestHandlerTest.php
@@ -9,7 +9,7 @@ use Gdbots\Pbj\WellKnown\Microtime;
 use Gdbots\Schemas\Iam\RoleId;
 use Gdbots\Tests\Iam\AbstractPbjxTest;
 
-class GetRoleRequestHandlerTest extends AbstractPbjxTest
+final class GetRoleRequestHandlerTest extends AbstractPbjxTest
 {
     public function testHandleRequest()
     {
@@ -30,7 +30,7 @@ class GetRoleRequestHandlerTest extends AbstractPbjxTest
     }
 
     /**
-     * @expectedException Gdbots\Ncr\Exception\NodeNotFound
+     * @expectedException \Gdbots\Ncr\Exception\NodeNotFound
      * @expectedExceptionMessage No method available to find role.
      */
     public function testHandleNodeRefNotFound()
@@ -42,7 +42,7 @@ class GetRoleRequestHandlerTest extends AbstractPbjxTest
     }
 
     /**
-     * @expectedException Gdbots\Ncr\Exception\NodeNotFound
+     * @expectedException \Gdbots\Ncr\Exception\NodeNotFound
      */
     public function testHandleNodeNotFound()
     {

--- a/tests/GetUserBatchRequestHandlerTest.php
+++ b/tests/GetUserBatchRequestHandlerTest.php
@@ -9,7 +9,7 @@ use Gdbots\Iam\GetUserBatchRequestHandler;
 use Gdbots\Schemas\Ncr\Mixin\Node\Node;
 use Gdbots\Schemas\Ncr\NodeRef;
 
-class GetUserBatchRequestHandlerTest extends AbstractPbjxTest
+final class GetUserBatchRequestHandlerTest extends AbstractPbjxTest
 {
     public function testHandleRequest()
     {

--- a/tests/GetUserRequestHandlerTest.php
+++ b/tests/GetUserRequestHandlerTest.php
@@ -10,7 +10,7 @@ use Gdbots\Iam\GetUserRequestHandler;
 use Gdbots\Pbj\SchemaQName;
 use Gdbots\Schemas\Ncr\NodeRef;
 
-class GetUserRequestHandlerTest extends AbstractPbjxTest
+final class GetUserRequestHandlerTest extends AbstractPbjxTest
 {
     public function testGetByNodeRefThatExists()
     {

--- a/tests/GrantRolesToUserHandlerTest.php
+++ b/tests/GrantRolesToUserHandlerTest.php
@@ -10,7 +10,7 @@ use Gdbots\Schemas\Ncr\NodeRef;
 use Gdbots\Schemas\Pbjx\Mixin\Event\Event;
 use Gdbots\Schemas\Pbjx\StreamId;
 
-class GrantRolesToUserHandlerTest extends AbstractPbjxTest
+final class GrantRolesToUserHandlerTest extends AbstractPbjxTest
 {
     public function testHandleCommand()
     {

--- a/tests/ListAllRolesRequestHandlerTest.php
+++ b/tests/ListAllRolesRequestHandlerTest.php
@@ -9,7 +9,7 @@ use Gdbots\Iam\ListAllRolesRequestHandler;
 use Gdbots\Schemas\Iam\RoleId;
 use Gdbots\Schemas\Ncr\NodeRef;
 
-class ListAllRolesRequestHandlerTest extends AbstractPbjxTest
+final class ListAllRolesRequestHandlerTest extends AbstractPbjxTest
 {
     public function testWithResultsExpected()
     {

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -9,7 +9,7 @@ use Gdbots\Schemas\Iam\Mixin\Role\Role;
 use Gdbots\Schemas\Iam\RoleId;
 use PHPUnit\Framework\TestCase;
 
-class PolicyTest extends TestCase
+final class PolicyTest extends TestCase
 {
     /**
      * @dataProvider getIsGrantedSamples

--- a/tests/RoleProjectorTest.php
+++ b/tests/RoleProjectorTest.php
@@ -9,10 +9,9 @@ use Acme\Schemas\Iam\Event\RoleUpdatedV1;
 use Acme\Schemas\Iam\Node\RoleV1;
 use Gdbots\Iam\RoleProjector;
 use Gdbots\Schemas\Iam\RoleId;
-use Gdbots\Schemas\Ncr\Enum\NodeStatus;
 use Gdbots\Schemas\Ncr\NodeRef;
 
-class RoleProjectorTest extends AbstractPbjxTest
+final class RoleProjectorTest extends AbstractPbjxTest
 {
     /** @var RoleProjector */
     protected $roleProjecter;
@@ -89,7 +88,7 @@ class RoleProjectorTest extends AbstractPbjxTest
     }
 
     /**
-     * testOnRoleDeleted
+     * @expectedException \Gdbots\Ncr\Exception\NodeNotFound
      */
     public function testOnRoleDeleted(): void
     {
@@ -98,20 +97,16 @@ class RoleProjectorTest extends AbstractPbjxTest
         $this->ncr->putNode($role);
 
         $event = RoleDeletedV1::create()->set('node_ref', $nodeRef);
-
         $this->roleProjecter->onRoleDeleted($event);
 
-        $deletedRole = $this->ncr->getNode($nodeRef);
-        $this->assertEquals(NodeStatus::DELETED(), $deletedRole->get('status'));
+        $this->ncr->getNode($nodeRef);
     }
 
-    /**
-     * @expectedException \Gdbots\Ncr\Exception\NodeNotFound
-     */
     public function testOnRoleDeletedNodeRefNotExists(): void
     {
         $event = RoleDeletedV1::create()->set('node_ref', NodeRef::fromString('acme:role:role-not-exists'));
         $this->roleProjecter->onRoleDeleted($event);
+        $this->assertTrue(true, 'No exception on missing node_ref');
     }
 
     /**

--- a/tests/UpdateUserHandlerTest.php
+++ b/tests/UpdateUserHandlerTest.php
@@ -11,8 +11,7 @@ use Gdbots\Schemas\Ncr\Enum\NodeStatus;
 use Gdbots\Schemas\Pbjx\Mixin\Event\Event;
 use Gdbots\Schemas\Pbjx\StreamId;
 
-
-class UpdateUserHandlerTest extends AbstractPbjxTest
+final class UpdateUserHandlerTest extends AbstractPbjxTest
 {
     public function testUpdateUser()
     {

--- a/tests/UserProjectorTest.php
+++ b/tests/UserProjectorTest.php
@@ -16,7 +16,7 @@ use Gdbots\Schemas\Iam\RoleId;
 use Gdbots\Schemas\Ncr\Enum\NodeStatus;
 use Gdbots\Schemas\Ncr\NodeRef;
 
-class UserProjectorTest extends AbstractPbjxTest
+final class UserProjectorTest extends AbstractPbjxTest
 {
     /** @var UserProjector */
     protected $userProjector;

--- a/tests/Validator/UniqueRoleValidatorTest.php
+++ b/tests/Validator/UniqueRoleValidatorTest.php
@@ -15,7 +15,7 @@ use Gdbots\Schemas\Iam\RoleId;
 use Gdbots\Schemas\Pbjx\StreamId;
 use Gdbots\Tests\Iam\AbstractPbjxTest;
 
-class UniqueRoleValidatorTest extends AbstractPbjxTest
+final class UniqueRoleValidatorTest extends AbstractPbjxTest
 {
     public function setup()
     {

--- a/tests/Validator/UniqueUserValidatorTest.php
+++ b/tests/Validator/UniqueUserValidatorTest.php
@@ -13,7 +13,7 @@ use Gdbots\Pbjx\Event\PbjxEvent;
 use Gdbots\Schemas\Pbjx\StreamId;
 use Gdbots\Tests\Iam\AbstractPbjxTest;
 
-class UniqueUserValidatorTest extends AbstractPbjxTest
+final class UniqueUserValidatorTest extends AbstractPbjxTest
 {
     public function setup()
     {


### PR DESCRIPTION
* Require `"gdbots/ncr": "~0.2"`.
* Add `PbjxValidator` and `PbjxProjector` marker interfaces to appropriate classes.
* issue #5: Update `RoleProjector` to use hard delete.